### PR TITLE
Mark all tag entries as "not required" by default

### DIFF
--- a/src/main/resources/data/forge/tags/items/bones/dragon.json
+++ b/src/main/resources/data/forge/tags/items/bones/dragon.json
@@ -1,6 +1,9 @@
 {
   "replace": false,
   "values": [
-    "iceandfire:dragonbone"
+    {
+      "id": "iceandfire:dragonbone",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/forge/tags/items/scales/fire_dragon.json
+++ b/src/main/resources/data/forge/tags/items/scales/fire_dragon.json
@@ -1,9 +1,21 @@
 {
   "replace": false,
   "values": [
-    "iceandfire:dragonscales_red",
-    "iceandfire:dragonscales_green",
-    "iceandfire:dragonscales_bronze",
-    "iceandfire:dragonscales_gray"
+    {
+      "id": "iceandfire:dragonscales_red",
+      "required": false
+    },
+    {
+      "id": "iceandfire:dragonscales_green",
+      "required": false
+    },
+    {
+      "id": "iceandfire:dragonscales_bronze",
+      "required": false
+    },
+    {
+      "id": "iceandfire:dragonscales_gray",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/forge/tags/items/scales/ice_dragon.json
+++ b/src/main/resources/data/forge/tags/items/scales/ice_dragon.json
@@ -1,9 +1,21 @@
 {
   "replace": false,
   "values": [
-    "iceandfire:dragonscales_blue",
-    "iceandfire:dragonscales_white",
-    "iceandfire:dragonscales_sapphire",
-    "iceandfire:dragonscales_silver"
+    {
+      "id": "iceandfire:dragonscales_blue",
+      "required": false
+    },
+    {
+      "id": "iceandfire:dragonscales_white",
+      "required": false
+    },
+    {
+      "id": "iceandfire:dragonscales_sapphire",
+      "required": false
+    },
+    {
+      "id": "iceandfire:dragonscales_silver",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/forge/tags/items/scales/lightning_dragon.json
+++ b/src/main/resources/data/forge/tags/items/scales/lightning_dragon.json
@@ -1,9 +1,21 @@
 {
   "replace": false,
   "values": [
-    "iceandfire:dragonscales_electric",
-    "iceandfire:dragonscales_amythest",
-    "iceandfire:dragonscales_copper",
-    "iceandfire:dragonscales_black"
+    {
+      "id": "iceandfire:dragonscales_electric",
+      "required": false
+    },
+    {
+      "id": "iceandfire:dragonscales_amythest",
+      "required": false
+    },
+    {
+      "id": "iceandfire:dragonscales_copper",
+      "required": false
+    },
+    {
+      "id": "iceandfire:dragonscales_black",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/forge/tags/items/scales/sea_serpent.json
+++ b/src/main/resources/data/forge/tags/items/scales/sea_serpent.json
@@ -1,12 +1,33 @@
 {
   "replace": false,
   "values": [
-    "iceandfire:sea_serpent_scales_blue",
-    "iceandfire:sea_serpent_scales_bronze",
-    "iceandfire:sea_serpent_scales_deepblue",
-    "iceandfire:sea_serpent_scales_green",
-    "iceandfire:sea_serpent_scales_purple",
-    "iceandfire:sea_serpent_scales_red",
-    "iceandfire:sea_serpent_scales_teal"
+    {
+      "id": "iceandfire:sea_serpent_scales_blue",
+      "required": false
+    },
+    {
+      "id": "iceandfire:sea_serpent_scales_bronze",
+      "required": false
+    },
+    {
+      "id": "iceandfire:sea_serpent_scales_deepblue",
+      "required": false
+    },
+    {
+      "id": "iceandfire:sea_serpent_scales_green",
+      "required": false
+    },
+    {
+      "id": "iceandfire:sea_serpent_scales_purple",
+      "required": false
+    },
+    {
+      "id": "iceandfire:sea_serpent_scales_red",
+      "required": false
+    },
+    {
+      "id": "iceandfire:sea_serpent_scales_teal",
+      "required": false
+    }
   ]
 }


### PR DESCRIPTION
This PR marks all tag entries present in `src/main/resources/data/forge/tags/items/...` as "not required" by default, which fixes tags failing to load when the mod "Ice and Fire" is not present.